### PR TITLE
optimize

### DIFF
--- a/src/raster04_rasterization.cpp
+++ b/src/raster04_rasterization.cpp
@@ -162,10 +162,23 @@ void rasterize(
             float fxL = ratioL * (fy - midYp.y) + midL;
             float fxR = ratioR * (fy - midYp.y) + midR;
             for (int x = (int)(fxL + 0.5f); x < (int)(fxR + 0.5f); x++) {
-                //float fx = x + 0.5f;
+                float fx = x + 0.5f;
                 // varying attributes
-                // ...
-                fb.setPixel(x, y, glm::vec3{0.5f,0.5f,0.5f});
+                const auto p = glm::vec2(fx, fy);
+                const auto b1 = edgeFunc(p2, p3, p) / denom;
+                const auto b2 = edgeFunc(p3, p1, p) / denom;
+                const auto b3 = edgeFunc(p1, p2, p) / denom;
+                /*
+                const auto p_ndc = b1 * p1_ndc + b2 * p2_ndc + b3 * p3_ndc;
+                if (fb.zbuf[y*fb.w + x] < p_ndc.z) {
+                    continue;
+                }
+                fb.zbuf[y*fb.w + x] = p_ndc.z;
+                */
+                const auto n = glm::normalize(b1/v1.p.w*v1.n + b2/v2.p.w*v2.n + b3/v3.p.w*v3.n);
+                // color
+                const auto c = glm::abs(n);
+                fb.setPixel(x, y, c);
             }
         }
         ratioL = (maxYp.x - midL) / (maxYp.y - midYp.y);
@@ -175,10 +188,23 @@ void rasterize(
             float fxL = ratioL * (fy - midYp.y) + midL;
             float fxR = ratioR * (fy - midYp.y) + midR;
             for (int x = (int)(fxL + 0.5f); x < (int)(fxR + 0.5f); x++) {
-                //float fx = x + 0.5f;
+                float fx = x + 0.5f;
                 // varying attributes
-                // ...
-                fb.setPixel(x, y, glm::vec3{0.25f,0.25f,0.25f});
+                const auto p = glm::vec2(fx, fy);
+                const auto b1 = edgeFunc(p2, p3, p) / denom;
+                const auto b2 = edgeFunc(p3, p1, p) / denom;
+                const auto b3 = edgeFunc(p1, p2, p) / denom;
+                /*
+                const auto p_ndc = b1 * p1_ndc + b2 * p2_ndc + b3 * p3_ndc;
+                if (fb.zbuf[y*fb.w + x] < p_ndc.z) {
+                    continue;
+                }
+                fb.zbuf[y*fb.w + x] = p_ndc.z;
+                */
+                const auto n = glm::normalize(b1/v1.p.w*v1.n + b2/v2.p.w*v2.n + b3/v3.p.w*v3.n);
+                // color
+                const auto c = glm::abs(n);
+                fb.setPixel(x, y, c);
             }
         }
 #else


### PR DESCRIPTION
1280x720, RGBA, cube.obj, normal

|CPU|OS|before [fps]|(AVX2 [fps])|after [fps]|
|--------------------------------|------|----|----|----|
|Ryzen 5 5600X @ 3.7GHz(4.6GHz), Zen3|Win 10|77.5|335|130|
|i5-6500 @ 3.20GHz(3.60GHz), Skylake|Win 10|39.9|171|60.7|
|i7-3770T @ 2.50(3.70GHz), Ivy Bridge|Win 10|23.4|-|41.6|
|Core2Duo L9400 @ 1.86GHz|Win 10|8.9|-|16.3|
|i5-8257U @ 1.4GHz(3.9GHz), Coffee Lake|macOS (retina on)|10.5|54.0|17.4|
|i5-8257U @ 1.4GHz(3.9GHz), Coffee Lake|macOS (retina off)|42.1|212|66.3|